### PR TITLE
Fix #32 - wrong container id

### DIFF
--- a/src/js/modules/player.mjs
+++ b/src/js/modules/player.mjs
@@ -207,6 +207,6 @@ export class YTMainPlayer extends withChapterNavigation(
     YTChapterList
 ) {
     constructor() {
-        super("movie_player", "description");
+        super("movie_player", "meta-contents");
     }
 }


### PR DESCRIPTION
Change container id to "meta-contents" (fixes #32).