### PR TITLE
Fix #72 - Invalidate controls after they are added

### DIFF
--- a/src/js/modules/player.mjs
+++ b/src/js/modules/player.mjs
@@ -100,20 +100,22 @@ export const withChapterNavigation = (YTPlayer, ChapterList) =>
                 return;
             }
 
-            if (
+            const chapterTitleAdded = 
                 mutations.length <= 1 ||
-                (mutations[0].removedNodes[0] ?? mutations[1].removedNodes[0]).textContent === ""
-            ) {
+                (mutations[0].removedNodes[0] ?? mutations[1].removedNodes[0]).textContent === "";
+            if (chapterTitleAdded) {
                 this.addChapterControls();
             }
 
             const playerVideo = this.videoElement;
-            if (playerVideo.paused) {
-                playerVideo.addEventListener("seeked", () => this.invalidateChapterControls(), {
-                    once: true,
-                });
-            } else {
+            if (chapterTitleAdded || !playerVideo.paused) {
                 this.invalidateChapterControls();
+            } else {
+                playerVideo.addEventListener(
+                    "seeked",
+                    () => this.invalidateChapterControls(),
+                    { once: true }
+                );
             }
         }
 

--- a/tests/jest-enfluenter.mjs
+++ b/tests/jest-enfluenter.mjs
@@ -1,13 +1,14 @@
 import { waitFor} from "./testing-library-dom.mjs";
 
-export const by = (asserting, expectation) => () => asserting(expectation);
-export const expecting = (...actuals) => (assert) => actuals.forEach(actual => assert(expect(actual())));
-export const waitingFor = (...actuals) => (assert) => waitFor(() => actuals.forEach(actual => assert(expect(actual()))));
-export const not = (assert) => (expectElement) => assert(expectElement.not);
+export const by = (assertOrPromise, toMatch) => () => assertOrPromise(toMatch);
+export const expecting = (...actuals) => (toMatch) => actuals.forEach(actual => toMatch(expect(actual())));
+export const waitingFor = (...actuals) => (toMatch) => waitFor(() => actuals.forEach(actual => toMatch(expect(actual()))));
+export const timeoutWhile = (awaiting) => (toMatch) => expect(awaiting(toMatch)).rejects.toThrow();
+export const not = (assert) => (expectElementOrFun) => assert(expectElementOrFun.not);
 
 export const toBeDisabled = (expectElement) => expectElement.toBeDisabled();
 export const toBeEmptyDOMElement = (expectElement) => expectElement.toBeEmptyDOMElement();
 export const toBeInTheDocument = (expectElement) => expectElement.toBeInTheDocument();
 
 export const toHaveBeenCalled = (expectMockFun) => expectMockFun.toHaveBeenCalled();
-export const toHaveBeenCalledWith = (args) => (expectElement) => expectElement.toHaveBeenCalledWith(args());
+export const toHaveBeenCalledWith = (args) => (expectMockFun) => expectMockFun.toHaveBeenCalledWith(args());


### PR DESCRIPTION
Fix #72. Invalidate controls on first chapter title change when video auto play is off.